### PR TITLE
force _content to be bytes, not bytearray

### DIFF
--- a/aiocouchdb/client.py
+++ b/aiocouchdb/client.py
@@ -237,7 +237,7 @@ class HttpResponse(aiohttp.client.ClientResponse):
             else:
                 self.close()
 
-            self._content = data
+            self._content = bytes(data)
 
         return self._content
 


### PR DESCRIPTION
having _content as bytearray causes chardet to throw a ValueError. Here is an example of requesting a non-existing design doc.

```
Traceback (most recent call last):
  File "/home/vukasin/.local/lib64/python3.4/site-packages/aiohttp/server.py", line 272, in start
    yield from self.handle_request(message, payload)
  File "/home/vukasin/.local/lib64/python3.4/site-packages/aiohttp/web.py", line 85, in handle_request
    resp = yield from handler(request)
  File "/usr/lib64/python3.4/asyncio/tasks.py", line 105, in coro
    res = yield from res
  File "/home/vukasin/peach-2/peach/queue/__init__.py", line 43, in get
    q = yield from ddoc.view("queue", name)
  File "/home/vukasin/.local/lib64/python3.4/site-packages/aiocouchdb/v1/designdoc.py", line 332, in view
    params=params))
  File "/home/vukasin/.local/lib64/python3.4/site-packages/aiocouchdb/views.py", line 52, in request
    yield from resp.maybe_raise_error()
  File "/home/vukasin/.local/lib64/python3.4/site-packages/aiocouchdb/errors.py", line 140, in maybe_raise_error
    data = yield from resp.json()
  File "/home/vukasin/.local/lib64/python3.4/site-packages/aiohttp/client_reqrep.py", line 703, in json
    encoding = self._get_encoding()
  File "/home/vukasin/.local/lib64/python3.4/site-packages/aiohttp/client_reqrep.py", line 671, in _get_encoding
    encoding = chardet.detect(self._content)['encoding']
  File "/home/vukasin/.local/lib64/python3.4/site-packages/chardet/__init__.py", line 26, in detect
    raise ValueError('Expected a bytes object, not a unicode object')
ValueError: Expected a bytes object, not a unicode object
```